### PR TITLE
Improve README with example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-Should deliver a interface for a tecplot binary file for python.
+Python Tecplot PLT Reader
+========================
+
+This project provides Python utilities to parse Tecplot binary (`.plt`) files.
+It uses the [`construct`](https://pypi.org/project/construct/) library to
+interpret the binary structures and [`numpy`](https://numpy.org/) for handling
+arrays of values.
+
+Requirements
+------------
+* construct
+* numpy
+
+Example
+-------
+```python
+import tecplotPltReader
+
+# Load the PLT file
+with open('data.plt', 'rb') as f:
+    raw = f.read()
+    header = tecplotPltReader.read_header(raw)
+    data = tecplotPltReader.read_data(raw, header, f)
+
+print(header['Title'])
+print(data['Zones'][0].keys())
+```
+


### PR DESCRIPTION
## Summary
- document project purpose for reading Tecplot PLT files
- list dependencies (`construct` and `numpy`)
- provide a short usage example

## Testing
- `python tecplotPltReaderTest.py` *(fails: ModuleNotFoundError: No module named 'construct')*