### PR TITLE
Add setup.py for module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-Should deliver a interface for a tecplot binary file for python.
+Simple interface for a Tecplot binary file for Python.
+
+## Installation
+
+Install from source using pip:
+
+```bash
+pip install .
+```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='tecplotPltReader',
+    version='0.1.0',
+    py_modules=['tecplotPltReader'],
+    description='Interface for reading Tecplot binary files in Python',
+    long_description=open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
+    author='Dark Light',
+    license='MIT',
+)


### PR DESCRIPTION
## Summary
- add README instructions for installing
- add simple `setup.py` so `tecplotPltReader.py` can be installed as a module

## Testing
- `python tecplotPltReaderTest.py` *(fails: No module named 'construct')*