### PR TITLE
Add pyproject.toml for wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tecplot-plt-reader"
+version = "0.1.0"
+description = "Python Tecplot PLT Reader"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+authors = [{name = "Dark Light"}]
+dependencies = ["numpy"]
+
+[tool.setuptools]
+py-modules = ["tecplotPltReader"]
+


### PR DESCRIPTION
## Summary
- enable modern setuptools packaging with a new `pyproject.toml`

## Testing
- `python -m unittest tecplotPltReaderTest.py -v`